### PR TITLE
Added config line config.ssh.insert_key = false

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,6 +9,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provision :shell, :path => "bootstrap.sh"
   config.vm.network :forwarded_port, host: 8082, guest: 80
   config.vm.synced_folder ".", "/vagrant", :mount_options => ["dmode=775,fmode=664"]
+# following line prevent vagrant to change default key pair
+# without it you cannot login second time (but should be, may be some additional settings required)
+  config.ssh.insert_key = false
   if Vagrant.has_plugin?("vagrant-cachier")
     config.cache.auto_detect = true
   end


### PR DESCRIPTION
preventing vagrant to change default ssh key pair.
Without it you fall to login to box second time it starts.
My be there should be more sophisticated settings applied,
as my solution follows to security leakage, but for testing purposes
this measure suitable.
